### PR TITLE
Add testing setup

### DIFF
--- a/backend/api-service/jest.config.js
+++ b/backend/api-service/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/?(*.)+(spec|test).[tj]s?(x)']
+};

--- a/backend/api-service/package.json
+++ b/backend/api-service/package.json
@@ -7,7 +7,7 @@
     "dev": "nodemon --exec ts-node -P tsconfig.dev.json src/server.ts",
     "build": "tsc",
     "start": "node dist/server.js",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "lint": "echo \"No linter configured yet\"",
     "clean": "rm -rf dist"
   },
@@ -52,6 +52,9 @@
     "ws": "^8.18.3"
   },
   "devDependencies": {
-    "@types/uuid": "^10.0.0"
+    "@types/uuid": "^10.0.0",
+    "@types/jest": "^29.5.11",
+    "jest": "^30.0.4",
+    "ts-jest": "^29.1.1"
   }
 }

--- a/backend/api-service/src/utils/validation.test.ts
+++ b/backend/api-service/src/utils/validation.test.ts
@@ -1,0 +1,11 @@
+import { validateEmail } from './validation';
+
+describe('validateEmail', () => {
+  it('returns true for valid email', () => {
+    expect(validateEmail('test@example.com')).toBe(true);
+  });
+
+  it('returns false for invalid email', () => {
+    expect(validateEmail('invalid-email')).toBe(false);
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@ant-design/plots": "^2.6.0",
@@ -38,6 +39,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.1",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.5.2",
@@ -46,10 +49,12 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.2.0",
+    "jsdom": "^26.1.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.34.1",
-    "vite": "^7.0.0"
+    "vite": "^7.0.0",
+    "vitest": "^1.4.0"
   }
 }

--- a/frontend/src/utils/formatters.test.ts
+++ b/frontend/src/utils/formatters.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import { formatCurrency } from './formatters';
+
+describe('formatCurrency', () => {
+  it('formats a number as USD currency', () => {
+    expect(formatCurrency(1234.56)).toBe('$1,234.56');
+  });
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -13,4 +13,8 @@ export default defineConfig({
     minify: false,
     sourcemap: true,
   },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
 })


### PR DESCRIPTION
## Summary
- set up Jest with `ts-jest` for the API service
- set up Vitest for the frontend
- add sample unit tests demonstrating the setup

## Testing
- `npm test --silent` in `backend/api-service`
- `npx vitest run` in `frontend`


------
https://chatgpt.com/codex/tasks/task_b_686d08d38a208323921964d4af4afeb6